### PR TITLE
Int test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+.vscode
+.docstring
+build/*
+dist/*
+data/*
+development/*
+*.egg-info/
+__pycache__

--- a/ames_qsar/out_fileread.py
+++ b/ames_qsar/out_fileread.py
@@ -1,15 +1,7 @@
 import os
-import glob
 
 def out_fileread(filepath):
-    os.chdir(filepath)
 
-    namelist = []
-    #This could be adjusted later to locate other extentions
-    for filename in glob.glob('*.out'):
-        
-        #removing the filepath leaves just the filename
-        filename = filename.replace(str(filepath), '')
-        namelist.append(filename)
+    namelist = [i for i in os.listdir(filepath) if '.out' in i]
 
     return namelist

--- a/ames_qsar/out_fileread.py
+++ b/ames_qsar/out_fileread.py
@@ -1,0 +1,15 @@
+import os
+import glob
+
+def out_fileread(filepath):
+    os.chdir(filepath)
+
+    namelist = []
+    #This could be adjusted later to locate other extentions
+    for filename in glob.glob('*.out'):
+        
+        #removing the filepath leaves just the filename
+        filename = filename.replace(str(filepath), '')
+        namelist.append(filename)
+
+    return namelist

--- a/tests/test_fileread.py
+++ b/tests/test_fileread.py
@@ -1,0 +1,15 @@
+import pytest
+import os
+import shutil
+
+#import the function to be tested
+from ames_qsar.out_fileread import out_fileread
+
+def test_fileread(tmpdir):
+    path = os.path.abspath(__file__)
+    dir_path = os.path.dirname(path)
+
+    #copy the files into a temporary directory
+    shutil.copytree(dir_path, tmpdir, ignore = shutil.ignore_patterns('*.py'), dirs_exist_ok=True)
+
+    assert set(out_fileread(tmpdir)) == set(['coumarin_gas.out','coumarin_neg.out','coumarin_pos.out' ])


### PR DESCRIPTION
updated version of the invalidated drafftest branch. This version uses a tmpdir for checking the file out_fileread.py. 